### PR TITLE
fixed shared memory warnings on Solr startup (when Solr is running in Docker container)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,8 @@ services:
   # DSpace Solr container
   dspacesolr:
     container_name: dspacesolr
+    environment:
+      SOLR_OPTS: -XX:-UseLargePages
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-latest}"
     build:
       context: ./dspace/src/main/docker/dspace-solr/


### PR DESCRIPTION
## Description

This PR fixes the warning you'll get on Solr startup (in the Solr Docker container):

```
2025-01-30 12:07:45 OpenJDK 64-Bit Server VM warning: Failed to reserve shared memory. (error = 1)
```

It was taken from https://solr.apache.org/guide/solr/latest/deployment-guide/docker-faq.html#how-can-i-get-rid-of-shared-memory-warnings-on-solr-startup
